### PR TITLE
Add WCB ingestion pipeline scaffolding

### DIFF
--- a/pg_keeper/__init__.py
+++ b/pg_keeper/__init__.py
@@ -1,0 +1,14 @@
+"""PG Keeper: WCB case assistant utilities."""
+
+__all__ = [
+    "config",
+    "storage",
+    "gmail_client",
+    "drive_client",
+    "categorizer",
+    "embeddings",
+    "pipeline",
+    "timeline",
+    "voice_io",
+    "cli",
+]

--- a/pg_keeper/categorizer.py
+++ b/pg_keeper/categorizer.py
@@ -1,0 +1,25 @@
+"""Heuristic categorizer for WCB documents."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+CATEGORIES = {
+    "wage": ["wage", "earning", "salary", "income"],
+    "medical_evidence": ["medical", "doctor", "clinic", "assessment", "MRI", "x-ray", "physio"],
+    "procedural_fairness": ["fairness", "notice", "opportunity", "timeline", "procedural"],
+    "policy": ["policy", "guideline", "act", "regulation", "wcb.ab.ca"],
+    "appeal": ["appeal", "appeals commission", "hearing", "decision"],
+    "communications": ["email", "correspondence", "letter", "submission"],
+}
+
+
+def categorize(text: str) -> str:
+    lowered = text.lower()
+    for category, keywords in CATEGORIES.items():
+        if any(word in lowered for word in keywords):
+            return category
+    return "uncategorized"
+
+
+def categories() -> Iterable[str]:
+    return CATEGORIES.keys()

--- a/pg_keeper/cli.py
+++ b/pg_keeper/cli.py
@@ -1,0 +1,64 @@
+"""Command-line entrypoints for PG Keeper."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from datetime import datetime
+
+from .config import load_config
+from .pipeline import IngestionPipeline
+from .timeline import Deadline, Timeline
+
+
+def ingest_demo(text_file: Path, attachments: list[Path]) -> None:
+    config = load_config()
+    pipeline = IngestionPipeline(config)
+    text = text_file.read_text(encoding="utf-8")
+    pipeline.process_item(text=text, attachments=attachments, subject=text_file.stem, source=str(text_file))
+    print(f"Ingested {text_file}")
+
+
+def show_deadlines() -> None:
+    config = load_config()
+    timeline = Timeline(config.storage_root)
+    for deadline in timeline.list_all():
+        print(f"{deadline.due.date()} - {deadline.title} ({deadline.notes or ''})")
+
+
+def add_deadline(title: str, due: str, notes: str | None) -> None:
+    config = load_config()
+    timeline = Timeline(config.storage_root)
+    timeline.add(Deadline(title=title, due=datetime.fromisoformat(due), notes=notes))
+    print("Deadline added.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PG Keeper CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest a text file and optional attachments")
+    ingest_parser.add_argument("text", type=Path, help="Path to text or email body file")
+    ingest_parser.add_argument("attachments", nargs="*", type=Path, help="Attachment paths")
+
+    deadline_parser = subparsers.add_parser("deadline", help="Add a deadline")
+    deadline_parser.add_argument("title", help="Title of the deadline")
+    deadline_parser.add_argument("due", help="Due date ISO format (YYYY-MM-DD)")
+    deadline_parser.add_argument("--notes", help="Optional notes")
+
+    subparsers.add_parser("deadlines", help="List deadlines")
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        ingest_demo(args.text, args.attachments)
+    elif args.command == "deadline":
+        add_deadline(args.title, args.due, args.notes)
+    elif args.command == "deadlines":
+        show_deadlines()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/pg_keeper/config.py
+++ b/pg_keeper/config.py
@@ -1,0 +1,42 @@
+"""Configuration loading for PG Keeper."""
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+
+@dataclass
+class KeeperConfig:
+    storage_root: Path
+    gmail_query: str
+    google_credentials_file: Path
+    embedding_model: str
+    openai_model: str
+    openai_api_key: str | None
+
+
+DEFAULT_STORAGE_ROOT = Path(os.environ.get("PG_KEEPER_STORAGE", "wcb-tools/documents")).expanduser()
+DEFAULT_GMAIL_QUERY = os.environ.get(
+    "PG_KEEPER_GMAIL_QUERY", "(subject:WCB OR \"Workers' Compensation Board\" OR WCB)"
+)
+DEFAULT_GOOGLE_CREDENTIALS_FILE = Path(
+    os.environ.get("PG_KEEPER_GOOGLE_CREDENTIALS", "~/.config/pg_keeper/google_credentials.json")
+).expanduser()
+DEFAULT_EMBEDDING_MODEL = os.environ.get(
+    "PG_KEEPER_EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+)
+DEFAULT_OPENAI_MODEL = os.environ.get("PG_KEEPER_OPENAI_MODEL", "gpt-4o-mini")
+DEFAULT_OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+
+
+def load_config() -> KeeperConfig:
+    storage_root = DEFAULT_STORAGE_ROOT
+    storage_root.mkdir(parents=True, exist_ok=True)
+
+    return KeeperConfig(
+        storage_root=storage_root,
+        gmail_query=DEFAULT_GMAIL_QUERY,
+        google_credentials_file=DEFAULT_GOOGLE_CREDENTIALS_FILE,
+        embedding_model=DEFAULT_EMBEDDING_MODEL,
+        openai_model=DEFAULT_OPENAI_MODEL,
+        openai_api_key=DEFAULT_OPENAI_API_KEY,
+    )

--- a/pg_keeper/drive_client.py
+++ b/pg_keeper/drive_client.py
@@ -1,0 +1,68 @@
+"""Google Drive client for pulling WCB-related files."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from google.oauth2.credentials import Credentials  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
+from googleapiclient.errors import HttpError  # type: ignore
+from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+from google.auth.transport.requests import Request  # type: ignore
+
+SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
+
+
+@dataclass
+class DriveFile:
+    id: str
+    name: str
+    mime_type: str
+    path: Path
+
+
+class DriveFetcher:
+    def __init__(self, credentials_file: Path, token_file: Path | None = None):
+        self.credentials_file = credentials_file
+        self.token_file = token_file or credentials_file.parent / "drive_token.json"
+        self.service = self._build_service()
+
+    def _build_service(self):
+        creds: Credentials | None = None
+        if self.token_file.exists():
+            creds = Credentials.from_authorized_user_file(self.token_file, SCOPES)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(self.credentials_file, SCOPES)
+                creds = flow.run_local_server(port=0)
+            with open(self.token_file, "w", encoding="utf-8") as token:
+                token.write(creds.to_json())
+        return build("drive", "v3", credentials=creds)
+
+    def search_files(self, query: str, limit: int = 50) -> Iterable[DriveFile]:
+        try:
+            results = self.service.files().list(q=query, pageSize=limit, fields="files(id, name, mimeType)").execute()
+        except HttpError as e:
+            raise RuntimeError(f"Drive API error: {e}")
+
+        for file in results.get("files", []):
+            yield DriveFile(id=file["id"], name=file["name"], mime_type=file["mimeType"], path=Path(file["name"]))
+
+    def download_file(self, drive_file: DriveFile, target_dir: Path) -> Path:
+        from googleapiclient.http import MediaIoBaseDownload  # type: ignore
+        import io
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / drive_file.name
+        request = self.service.files().get_media(fileId=drive_file.id)
+        fh = io.FileIO(target_path, "wb")
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while not done:
+            status, done = downloader.next_chunk()
+            if status:
+                print(f"Download progress: {int(status.progress() * 100)}%")
+        return target_path

--- a/pg_keeper/embeddings.py
+++ b/pg_keeper/embeddings.py
@@ -1,0 +1,75 @@
+"""Text splitting and embeddings for semantic search."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+from sentence_transformers import SentenceTransformer  # type: ignore
+
+
+@dataclass
+class Chunk:
+    id: str
+    text: str
+    vector: list[float]
+
+
+class EmbeddingIndexer:
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.model = SentenceTransformer(model_name)
+
+    @staticmethod
+    def split_text(text: str, chunk_size: int = 512, overlap: int = 50) -> List[str]:
+        words = text.split()
+        chunks: List[str] = []
+        start = 0
+        while start < len(words):
+            end = start + chunk_size
+            chunk_words = words[start:end]
+            chunks.append(" ".join(chunk_words))
+            if end >= len(words):
+                break
+            start = max(0, end - overlap)
+        return chunks
+
+    def build_index(self, text: str) -> List[Chunk]:
+        parts = self.split_text(text)
+        embeddings = self.model.encode(parts).tolist()
+        return [Chunk(id=f"chunk-{i}", text=chunk, vector=emb) for i, (chunk, emb) in enumerate(zip(parts, embeddings))]
+
+    @staticmethod
+    def save_index(chunks: Sequence[Chunk], path: Path) -> None:
+        payload = [chunk.__dict__ for chunk in chunks]
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    @staticmethod
+    def load_index(path: Path) -> List[Chunk]:
+        if not path.exists():
+            return []
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [Chunk(**item) for item in data]
+
+    @staticmethod
+    def cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
+        import math
+
+        dot = sum(a * b for a, b in zip(vec_a, vec_b))
+        norm_a = math.sqrt(sum(a * a for a in vec_a))
+        norm_b = math.sqrt(sum(b * b for b in vec_b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    def search(self, index: Sequence[Chunk], query: str, top_k: int = 5) -> List[tuple[float, Chunk]]:
+        query_vec = self.model.encode([query]).tolist()[0]
+        scored = [
+            (self.cosine_similarity(query_vec, chunk.vector), chunk) for chunk in index
+        ]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return scored[:top_k]

--- a/pg_keeper/gmail_client.py
+++ b/pg_keeper/gmail_client.py
@@ -1,0 +1,80 @@
+"""Gmail client utilities for fetching WCB correspondence."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Iterable, List
+
+# Google API imports are optional and will be loaded at runtime
+from google.oauth2.credentials import Credentials  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
+from googleapiclient.errors import HttpError  # type: ignore
+from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+from google.auth.transport.requests import Request  # type: ignore
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+
+@dataclass
+class GmailMessage:
+    id: str
+    subject: str | None
+    received_at: datetime
+    body_text: str
+    attachments: List[Path]
+
+
+class GmailFetcher:
+    def __init__(self, credentials_file: Path, token_file: Path | None = None):
+        self.credentials_file = credentials_file
+        self.token_file = token_file or credentials_file.parent / "gmail_token.json"
+        self.service = self._build_service()
+
+    def _build_service(self):
+        creds: Credentials | None = None
+        if self.token_file.exists():
+            creds = Credentials.from_authorized_user_file(self.token_file, SCOPES)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(self.credentials_file, SCOPES)
+                creds = flow.run_local_server(port=0)
+            with open(self.token_file, "w", encoding="utf-8") as token:
+                token.write(creds.to_json())
+        return build("gmail", "v1", credentials=creds)
+
+    def fetch_messages(self, query: str, limit: int = 25) -> Iterable[GmailMessage]:
+        try:
+            results = self.service.users().messages().list(userId="me", q=query, maxResults=limit).execute()
+        except HttpError as e:
+            raise RuntimeError(f"Gmail API error: {e}")
+
+        messages = results.get("messages", [])
+        for message in messages:
+            msg = self.service.users().messages().get(userId="me", id=message["id"], format="raw").execute()
+            payload = BytesParser(policy=policy.default).parsebytes(msg["raw"].encode("UTF-8"))
+            subject = payload["subject"]
+            received = payload["date"]
+            received_at = datetime.strptime(received, "%a, %d %b %Y %H:%M:%S %z") if received else datetime.utcnow()
+            body_text = payload.get_body(preferencelist=("plain", "html"))
+            text = body_text.get_content() if body_text else ""
+
+            attachments: List[Path] = []
+            for part in payload.iter_attachments():
+                filename = part.get_filename() or "attachment"
+                data = part.get_payload(decode=True)
+                target = Path(filename)
+                target.write_bytes(data)
+                attachments.append(target)
+
+            yield GmailMessage(
+                id=message["id"],
+                subject=subject,
+                received_at=received_at,
+                body_text=text,
+                attachments=attachments,
+            )

--- a/pg_keeper/pipeline.py
+++ b/pg_keeper/pipeline.py
@@ -1,0 +1,108 @@
+"""End-to-end ingestion pipeline for WCB artifacts."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from .categorizer import categorize
+from .config import KeeperConfig
+from .embeddings import EmbeddingIndexer
+from .storage import DocumentRecord, persist_document_record, save_attachment, save_text
+
+
+MODULES = [
+    "Loophole Finder",
+    "Fairness Review Expert",
+    "Appeal Strategist",
+    "Dirty Tactics Defender",
+]
+
+
+class CaseMemory:
+    def __init__(self, storage_root: Path):
+        self.storage_root = storage_root
+
+    @property
+    def memory_dir(self) -> Path:
+        return self.storage_root / "case_memory"
+
+    def save_module_outputs(self, identifier: str, outputs: Dict[str, str]) -> Path:
+        path = self.memory_dir / f"{identifier}_modules.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(outputs, f, indent=2)
+        return path
+
+
+class ModuleRouter:
+    def __init__(self, model_name: str, api_key: str | None):
+        self.model_name = model_name
+        self.api_key = api_key
+
+    def run_module(self, module_name: str, text: str) -> str:
+        # Placeholder: connect your preferred LLM here.
+        prompt = (
+            f"You are {module_name} focused on WCB claims. Analyse the text below and return"
+            f" concise, actionable notes. Text:\n{text[:4000]}"
+        )
+        # For offline safety we simply echo the prompt summary.
+        return f"[{module_name}] {prompt[:500]}..."
+
+    def route(self, text: str) -> Dict[str, str]:
+        return {module: self.run_module(module, text) for module in MODULES}
+
+
+class IngestionPipeline:
+    def __init__(self, config: KeeperConfig):
+        self.config = config
+        self.memory = CaseMemory(config.storage_root)
+        self.indexer = EmbeddingIndexer(config.embedding_model)
+        self.router = ModuleRouter(config.openai_model, config.openai_api_key)
+
+    def _build_identifier(self, subject: str | None) -> str:
+        base = subject or "wcb_item"
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        return f"{timestamp}_{base}"
+
+    def process_item(self, text: str, attachments: Iterable[Path], subject: str | None, source: str) -> DocumentRecord:
+        category = categorize(text)
+        identifier = self._build_identifier(subject)
+
+        text_path = save_text(text, self.config.storage_root, category, identifier)
+        saved_attachments: List[Path] = []
+        for attachment in attachments:
+            saved = save_attachment(attachment, self.config.storage_root, category, attachment.name)
+            saved_attachments.append(saved)
+
+        chunks = self.indexer.build_index(text)
+        embeddings_path = self.config.storage_root / category / f"{identifier}_embeddings.json"
+        self.indexer.save_index(chunks, embeddings_path)
+
+        module_outputs = self.router.route(text)
+        modules_path = self.memory.save_module_outputs(identifier, module_outputs)
+
+        record = DocumentRecord(
+            source=source,
+            subject=subject,
+            category=category,
+            received_at=datetime.utcnow(),
+            original_path=text_path,
+            text_path=text_path,
+            embeddings_path=embeddings_path,
+            module_outputs_path=modules_path,
+        )
+        persist_document_record(record, self.config.storage_root)
+        return record
+
+    def semantic_search(self, query: str, category: str | None = None, top_k: int = 5) -> List[Tuple[str, float, str]]:
+        results: List[Tuple[str, float, str]] = []
+        category_dir = self.config.storage_root / (category or "")
+        for path in category_dir.rglob("*_embeddings.json"):
+            chunks = self.indexer.load_index(path)
+            matches = self.indexer.search(chunks, query, top_k=top_k)
+            for score, match in matches:
+                results.append((path.name, score, match.text))
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:top_k]

--- a/pg_keeper/storage.py
+++ b/pg_keeper/storage.py
@@ -1,0 +1,70 @@
+"""Local storage helpers for PG Keeper."""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class DocumentRecord:
+    source: str
+    subject: str | None
+    category: str
+    received_at: datetime
+    original_path: Path
+    text_path: Path | None
+    embeddings_path: Path | None
+    module_outputs_path: Path | None
+
+
+def safe_filename(name: str) -> str:
+    return "".join(c if c.isalnum() or c in {"-", "_", "."} else "_" for c in name)
+
+
+def ensure_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def write_json(path: Path, payload: dict) -> None:
+    ensure_dir(path.parent)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+
+
+def save_attachment(content_path: Path, storage_root: Path, category: str, label: str) -> Path:
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    category_dir = ensure_dir(storage_root / category)
+    target_name = f"{timestamp}_{safe_filename(label)}{content_path.suffix}"
+    target_path = category_dir / target_name
+    shutil.copy2(content_path, target_path)
+    return target_path
+
+
+def save_text(text: str, storage_root: Path, category: str, label: str) -> Path:
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    category_dir = ensure_dir(storage_root / category)
+    target_name = f"{timestamp}_{safe_filename(label)}.txt"
+    target_path = category_dir / target_name
+    ensure_dir(target_path.parent)
+    with target_path.open("w", encoding="utf-8") as f:
+        f.write(text)
+    return target_path
+
+
+def persist_document_record(record: DocumentRecord, storage_root: Path) -> Path:
+    timeline_dir = ensure_dir(storage_root / "case_memory")
+    target_path = timeline_dir / f"{record.received_at.strftime('%Y%m%dT%H%M%SZ')}_{safe_filename(record.subject or record.source)}.json"
+    write_json(target_path, asdict(record))
+    return target_path
+
+
+def list_records(storage_root: Path) -> Iterable[Path]:
+    memory_dir = storage_root / "case_memory"
+    if not memory_dir.exists():
+        return []
+    return sorted(memory_dir.glob("*.json"))

--- a/pg_keeper/timeline.py
+++ b/pg_keeper/timeline.py
@@ -1,0 +1,51 @@
+"""Deadline tracking for WCB cases."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass
+class Deadline:
+    title: str
+    due: datetime
+    notes: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Deadline":
+        return cls(title=data["title"], due=datetime.fromisoformat(data["due"]), notes=data.get("notes"))
+
+
+class Timeline:
+    def __init__(self, storage_root: Path):
+        self.storage_root = storage_root
+        self.path = storage_root / "case_memory" / "deadlines.json"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> List[Deadline]:
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [Deadline.from_dict(item) for item in data]
+
+    def _save(self, deadlines: Iterable[Deadline]) -> None:
+        payload = [asdict(deadline) | {"due": deadline.due.isoformat()} for deadline in deadlines]
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    def add(self, deadline: Deadline) -> None:
+        deadlines = self._load()
+        deadlines.append(deadline)
+        self._save(deadlines)
+
+    def upcoming(self, within_days: int = 14) -> List[Deadline]:
+        now = datetime.utcnow()
+        window_end = now + timedelta(days=within_days)
+        return [d for d in self._load() if now <= d.due <= window_end]
+
+    def list_all(self) -> List[Deadline]:
+        return self._load()

--- a/pg_keeper/voice_io.py
+++ b/pg_keeper/voice_io.py
@@ -1,0 +1,36 @@
+"""Voice I/O utilities using speech_recognition and pyttsx3."""
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    import speech_recognition as sr  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    sr = None  # type: ignore
+
+try:
+    import pyttsx3  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    pyttsx3 = None  # type: ignore
+
+
+class VoiceInterface:
+    def __init__(self):
+        self.recognizer = sr.Recognizer() if sr else None
+        self.tts_engine = pyttsx3.init() if pyttsx3 else None
+
+    def listen(self, timeout: float = 10.0) -> Optional[str]:
+        if not self.recognizer or not sr:
+            raise RuntimeError("speech_recognition is not installed")
+        with sr.Microphone() as source:  # pragma: no cover - requires microphone
+            audio = self.recognizer.listen(source, timeout=timeout)
+        try:
+            return self.recognizer.recognize_google(audio)
+        except sr.UnknownValueError:
+            return None
+
+    def speak(self, text: str) -> None:
+        if not self.tts_engine:
+            raise RuntimeError("pyttsx3 is not installed")
+        self.tts_engine.say(text)
+        self.tts_engine.runAndWait()


### PR DESCRIPTION
## Summary
- add configuration, storage, and categorization helpers for WCB documents
- implement ingestion pipeline with embeddings, module routing, and semantic search stubs
- provide Gmail/Drive fetchers, deadline tracking, voice I/O, and CLI entrypoints

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695283734b4083299cff7549bb2bf7fe)