### PR TITLE
Add analysis agents and routing

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,9 @@
+"""Agent package exposing analyzers and router utilities."""
+
+from .base import Analyzer, AnalysisReport, AnalysisRequest, AnalyzerResult  # noqa: F401
+from .router import AnalysisRouter  # noqa: F401
+from .loophole_finder import LoopholeFinder  # noqa: F401
+from .fairness_reviewer import FairnessReviewer  # noqa: F401
+from .appeal_strategist import AppealStrategist  # noqa: F401
+from .dirty_tactics_defender import DirtyTacticsDefender  # noqa: F401
+from .case_memory_vault import CaseMemoryVault  # noqa: F401

--- a/agents/appeal_strategist.py
+++ b/agents/appeal_strategist.py
@@ -1,0 +1,22 @@
+"""Analyzer that drafts appeal strategies and deadlines."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Analyzer, AnalysisRequest
+
+
+class AppealStrategist(Analyzer):
+    name = "appeal_strategist"
+    prompt_template = (
+        "Outline appeal angles, evidence priorities, and filing deadlines for the WCB case."
+    )
+    guardrails = "Guardrail: avoid legal advice; suggest options for claimant review with counsel."
+
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        return [
+            self.prompt_template,
+            f"Appeal scenario: {request.content}",
+            "List critical dates and responsible parties for each action.",
+            self.guardrails,
+        ]

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,0 +1,63 @@
+"""Shared analyzer abstractions and logging helpers."""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AnalysisRequest:
+    """Input sent to analyzers."""
+
+    request_type: str
+    content: str
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AnalyzerResult:
+    """Container for an individual analyzer's insights."""
+
+    analyzer: str
+    insights: List[str]
+
+
+@dataclass
+class AnalysisReport:
+    """Aggregated analyzer output."""
+
+    request_type: str
+    results: List[AnalyzerResult]
+    combined_insights: List[str]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "request_type": self.request_type,
+            "results": [result.__dict__ for result in self.results],
+            "combined_insights": list(self.combined_insights),
+        }
+
+
+class Analyzer(ABC):
+    """Analyzer contract for specialized modules."""
+
+    name: str = "analyzer"
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(self.name)
+
+    @abstractmethod
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        """Analyze the request and return ordered insights."""
+
+    def run(self, request: AnalysisRequest) -> List[str]:
+        """Wrapper that adds logging around :meth:`analyze`."""
+
+        self.logger.info("Analyzing %s request", request.request_type)
+        insights = self.analyze(request)
+        self.logger.debug("%s produced %d insights", self.name, len(insights))
+        return insights

--- a/agents/case_memory_vault.py
+++ b/agents/case_memory_vault.py
@@ -1,0 +1,26 @@
+"""Analyzer that maintains structured case memory and reminders."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Analyzer, AnalysisRequest
+
+
+class CaseMemoryVault(Analyzer):
+    name = "case_memory_vault"
+    prompt_template = (
+        "Summarize key facts, actors, deadlines, and evidence locations for future recall."
+    )
+    guardrails = "Guardrail: preserve confidentiality, avoid speculative statements, and timestamp sources."
+
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        metadata_summary = (
+            f"Stored metadata: {request.metadata!r}" if request.metadata else "No extra metadata supplied."
+        )
+        return [
+            self.prompt_template,
+            f"Case memory update: {request.content}",
+            metadata_summary,
+            "Organize entries by category (medical, correspondence, filings, timelines).",
+            self.guardrails,
+        ]

--- a/agents/dirty_tactics_defender.py
+++ b/agents/dirty_tactics_defender.py
@@ -1,0 +1,22 @@
+"""Analyzer that defends against adversarial or obstructive tactics."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Analyzer, AnalysisRequest
+
+
+class DirtyTacticsDefender(Analyzer):
+    name = "dirty_tactics_defender"
+    prompt_template = (
+        "Identify obstruction, delay, or intimidation tactics and suggest polite, documented responses."
+    )
+    guardrails = "Guardrail: encourage de-escalation and documentation rather than confrontation."
+
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        return [
+            self.prompt_template,
+            f"Potential tactics in: {request.content}",
+            "Recommend responses that create a clear paper trail and preserve rights.",
+            self.guardrails,
+        ]

--- a/agents/fairness_reviewer.py
+++ b/agents/fairness_reviewer.py
@@ -1,0 +1,28 @@
+"""Analyzer that evaluates fairness and due process."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Analyzer, AnalysisRequest
+
+
+class FairnessReviewer(Analyzer):
+    name = "fairness_reviewer"
+    prompt_template = (
+        "Check for bias, due-process violations, and missing claimant voice. "
+        "Highlight requirements for balanced review and transparent communication."
+    )
+
+    guardrails = "Guardrail: flag remedies that promote equitable treatment without escalating conflict."
+
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        metadata_note = (
+            f"Metadata considered: {', '.join(sorted(request.metadata)) or 'none provided'}."
+        )
+        return [
+            self.prompt_template,
+            f"Fairness concerns in: {request.content}",
+            metadata_note,
+            self.guardrails,
+            "Provide checklist-style recommendations that are easy to verify.",
+        ]

--- a/agents/loophole_finder.py
+++ b/agents/loophole_finder.py
@@ -1,0 +1,28 @@
+"""Analyzer that surfaces procedural loopholes and process gaps."""
+from __future__ import annotations
+
+from typing import List
+
+from .base import Analyzer, AnalysisRequest
+
+
+class LoopholeFinder(Analyzer):
+    name = "loophole_finder"
+    prompt_template = (
+        "Identify procedural gaps or overlooked policies that support the "
+        "claimant. Focus on compliance-friendly suggestions and cite safe "
+        "documentation tactics."
+    )
+
+    guardrails = (
+        "Guardrail: stay within legal and ethical bounds, avoid proposing anything "
+        "that obstructs legitimate reviews."
+    )
+
+    def analyze(self, request: AnalysisRequest) -> List[str]:
+        return [
+            self.prompt_template,
+            f"Request focus: {request.content}",
+            self.guardrails,
+            "Deliver concise action items that can be evidenced with documents or timelines.",
+        ]

--- a/agents/router.py
+++ b/agents/router.py
@@ -1,0 +1,74 @@
+"""Route analysis requests to specialized analyzers and aggregate insights."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Sequence
+
+from .appeal_strategist import AppealStrategist
+from .base import AnalysisReport, AnalysisRequest, Analyzer, AnalyzerResult
+from .case_memory_vault import CaseMemoryVault
+from .dirty_tactics_defender import DirtyTacticsDefender
+from .fairness_reviewer import FairnessReviewer
+from .loophole_finder import LoopholeFinder
+
+logger = logging.getLogger(__name__)
+
+
+class AnalysisRouter:
+    """Orchestrates analyzers based on the request type."""
+
+    DEFAULT_ANALYZERS: Sequence[Analyzer] = (
+        LoopholeFinder(),
+        FairnessReviewer(),
+        AppealStrategist(),
+        DirtyTacticsDefender(),
+        CaseMemoryVault(),
+    )
+
+    ROUTE_MAP: Dict[str, Sequence[str]] = {
+        "loophole": (LoopholeFinder.name, DirtyTacticsDefender.name),
+        "fairness": (FairnessReviewer.name, DirtyTacticsDefender.name),
+        "appeal": (AppealStrategist.name, FairnessReviewer.name),
+        "memory": (CaseMemoryVault.name,),
+        "comprehensive": tuple(analyzer.name for analyzer in DEFAULT_ANALYZERS),
+    }
+
+    def __init__(self, analyzers: Sequence[Analyzer] | None = None) -> None:
+        self.analyzers = list(analyzers) if analyzers else list(self.DEFAULT_ANALYZERS)
+        self._analyzer_index: Dict[str, Analyzer] = {a.name: a for a in self.analyzers}
+
+    def select_analyzers(self, request_type: str) -> List[Analyzer]:
+        request_type = (request_type or "").lower()
+        names = self.ROUTE_MAP.get(request_type, tuple(analyzer.name for analyzer in self.analyzers))
+        selected = [self._analyzer_index[name] for name in names if name in self._analyzer_index]
+        logger.debug("Selected analyzers for %s: %s", request_type, [a.name for a in selected])
+        return selected
+
+    def analyze(self, request: AnalysisRequest) -> AnalysisReport:
+        analyzers = self.select_analyzers(request.request_type)
+        results: List[AnalyzerResult] = []
+        combined: List[str] = []
+
+        for analyzer in analyzers:
+            insights = analyzer.run(request)
+            results.append(AnalyzerResult(analyzer=analyzer.name, insights=insights))
+            combined.extend(insights)
+
+        combined = self._merge_insights(combined)
+        return AnalysisReport(
+            request_type=request.request_type,
+            results=results,
+            combined_insights=combined,
+        )
+
+    @staticmethod
+    def _merge_insights(insights: Iterable[str]) -> List[str]:
+        """Deduplicate while preserving order."""
+
+        seen = set()
+        merged: List[str] = []
+        for insight in insights:
+            if insight not in seen:
+                merged.append(insight)
+                seen.add(insight)
+        return merged

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,64 @@
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from agents import (
+    AnalysisRequest,
+    AnalysisRouter,
+    AppealStrategist,
+    CaseMemoryVault,
+    DirtyTacticsDefender,
+    FairnessReviewer,
+    LoopholeFinder,
+)
+
+
+@pytest.fixture(autouse=True)
+def configure_logging(caplog):
+    caplog.set_level(logging.DEBUG)
+
+
+def test_routes_specific_request_types():
+    router = AnalysisRouter()
+
+    loophole_selected = [a.name for a in router.select_analyzers("loophole")]
+    assert LoopholeFinder.name in loophole_selected
+    assert DirtyTacticsDefender.name in loophole_selected
+    assert FairnessReviewer.name not in loophole_selected
+
+    fairness_selected = [a.name for a in router.select_analyzers("fairness")]
+    assert fairness_selected == [FairnessReviewer.name, DirtyTacticsDefender.name]
+
+    memory_selected = [a.name for a in router.select_analyzers("memory")]
+    assert memory_selected == [CaseMemoryVault.name]
+
+
+def test_unknown_type_defaults_to_all_analyzers():
+    router = AnalysisRouter()
+
+    all_analyzer_names = {analyzer.name for analyzer in router.analyzers}
+    selected = {a.name for a in router.select_analyzers("unexpected")}
+
+    assert selected == all_analyzer_names
+
+
+def test_aggregates_insights_without_duplicates():
+    router = AnalysisRouter()
+    request = AnalysisRequest(request_type="appeal", content="Missed deadline", metadata={"source": "email"})
+
+    report = router.analyze(request)
+
+    analyzer_names = [result.analyzer for result in report.results]
+    assert analyzer_names == [AppealStrategist.name, FairnessReviewer.name]
+
+    # Combined insights preserve order and drop duplicates
+    flattened = [insight for result in report.results for insight in result.insights]
+    assert len(report.combined_insights) <= len(flattened)
+    assert report.combined_insights[0] == flattened[0]
+    assert len(report.combined_insights) == len(set(report.combined_insights))
+
+    assert report.as_dict()["request_type"] == "appeal"


### PR DESCRIPTION
## Summary
- add shared analyzer interface, request/response models, and logging wrappers
- implement specialized analyzers for loopholes, fairness, appeals, adversarial tactics, and case memory
- introduce router to select analyzers per request type and aggregate insights with tests for routing and merging

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69528ed2942c8329bfcd8c57662e6fdc)