### PR TITLE
Add offline WCB Super Advocate CLI wizard and packaging scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,84 @@
-# PG-keeper
+# WCB Super Advocate (offline-first)
 
-A lightweight toolkit to ingest Workers' Compensation Board case materials, chat with context, and draft responses via CLI or API.
+An offline-first assistant to organize Alberta WCB cases, extract text from local documents, and draft neutral letters using local templates. No internet is required and no cloud services are used.
 
-## Features
-- Ingest local files or directories into Chroma/FAISS
-- Chat over indexed context and view retrieved snippets
-- Draft concise notes or replies with configurable tone/length
-- Optional FastAPI service exposing `/chat` and `/draft`
+## Quick start (Windows one-click)
 
-## Installation
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .[api]
-```
+1. Install Python 3.11 or newer.
+2. Double-click `build_windows.bat`. This installs minimal dependencies and builds `dist\WCB_Super_Advocate.exe`.
+3. Double-click `dist\WCB_Super_Advocate.exe` to launch the guided wizard.
 
-## CLI Usage
-```bash
-pg-keeper-ingest ./case-vault
-pg-keeper-chat "What deadlines are mentioned?"
-pg-keeper-draft "Draft an appeal note summarizing the latest decision"
-```
+Everything stays local: cases are stored under `cases/<case_name>/`, and logs are written to `logs/app.log`.
 
-Set environment variables to configure behavior:
-- `PG_KEEPER_DATA_DIR` to control where data is stored (default `./data`)
-- `PG_KEEPER_CHROMA_URL` to point at a remote Chroma server (default in-process)
-- `PG_KEEPER_API_KEY` to protect the API (optional)
-- `PG_KEEPER_MODEL` to set the model name used in generated text
+## How to start a case
 
-## API Usage
-Start the API locally:
-```bash
-uvicorn api.app:app --reload
-```
+1. Choose **“Start new case”** in the wizard.
+2. Enter a simple case name (no special characters). Factual-Only Mode is on by default to avoid unverified policy text.
+3. The app creates `cases/<case_name>/` with `imports/`, `exports/`, `policy/`, and `notes/`.
+4. Follow the prompt: “Next step: import documents.”
 
-Make requests with an API key if configured:
-```bash
-curl -X POST http://localhost:8000/chat \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $PG_KEEPER_API_KEY" \
-  -d '{"query": "List missing evidence", "collection": "case-vault", "top_k": 3}'
+## How to import documents
 
-curl -X POST http://localhost:8000/draft \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Draft follow-up email to adjuster", "tone": "direct", "length": "medium"}'
-```
+1. Choose **“Import documents”**.
+2. Paste the full path to a PDF, DOCX, or TXT file (no internet needed). The file is copied into `cases/<case_name>/imports/`.
+3. Pick a tag (decision, medical, correspondence, employer, wage, rtw, or other). Text extraction runs automatically.
+4. If a file cannot be read, you’ll see a friendly message and the app keeps running. Errors also log to `logs/app.log`.
+5. Next step suggestions guide you to build the timeline or issues.
 
-## Docker
-Build and run the API with Chroma via Docker Compose:
-```bash
-docker-compose up --build
-```
+## How to build the timeline
 
-This starts Chroma on port 8001 and the API on port 8000 with a shared `./data` volume.
+1. Choose **“Build timeline.”**
+2. Enter dates (YYYY-MM-DD) and short descriptions. Optionally link an imported document.
+3. Press Enter on an empty date to finish. Entries are saved to `case_state.json` and exported later.
+
+## How to build the issues list
+
+1. Choose **“Build issues list.”**
+2. Add concise, neutral issue titles and concerns (e.g., “Clarify wage recalculation”).
+3. Link documents if helpful, or skip. Press Enter on an empty title to finish.
+
+## How to draft letters
+
+1. Choose **“Draft appeal/review/disclosure letter.”**
+2. Pick one of the local templates:
+   - Appeal/Review submission skeleton
+   - Fairness Review letter skeleton
+   - Disclosure request letter skeleton
+3. Drafts use only the timeline, issues, and policy files in your case `policy/` folder. If no policy text is available, the draft states “Policy source not provided yet.”
+4. Outputs are saved to `cases/<case_name>/exports/` as both `.txt` and `.docx`.
+
+## How to export drafts and checklists
+
+1. Choose **“Export package (TXT + DOCX + JSON).”**
+2. The app writes:
+   - `timeline_<timestamp>.txt` and `.json`
+   - `issues_<timestamp>.txt` and `.json`
+   - `contradictions_checklist_<timestamp>.txt`
+3. Review everything in `cases/<case_name>/exports/`.
+
+## Development (optional)
+
+- Run from source on Windows: double-click `run_dev.bat`.
+- On other platforms:
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate
+  pip install -r requirements.txt
+  python -m wcb_app.main wizard
+  ```
+- Diagnostics command: `python -m wcb_app.main diagnostics`
+
+## Templates and samples
+
+- Templates live in `templates/`:
+  - `appeal_submission.j2`
+  - `fairness_review.j2`
+  - `disclosure_request.j2`
+- A tiny demo case is in `sample_cases/demo_case/`. Copy it into `cases/` if you want to explore before adding your own data.
+
+## Safety and scope
+
+- Offline-first; no network access required.
+- No legal advice. Drafts include a reminder to stay neutral (“I’m concerned that…”, “It appears…”).
+- No requests for SIN or banking info.
+- Policy text is only cited if stored in the local `policy/` folder or supplied by you. Otherwise the app states: “Policy source not provided yet.”

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,10 @@
+@echo off
+REM Build a single EXE for WCB Super Advocate using PyInstaller.
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+pyinstaller --noconfirm --onefile --name WCB_Super_Advocate ^
+  --add-data "templates;templates" ^
+  --add-data "sample_cases;sample_cases" ^
+  wcb_app/main.py
+
+echo Build complete. You can run dist\WCB_Super_Advocate.exe by double-clicking it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pydantic>=2.6,<3.0
+rich>=13.7
+typer>=0.9
+python-docx>=1.1
+pypdf>=4.3
+jinja2>=3.1
+PyInstaller>=6.10

--- a/run_dev.bat
+++ b/run_dev.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Run the WCB Super Advocate wizard from source for testing.
+python -m venv .venv
+call .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m wcb_app.main wizard

--- a/sample_cases/demo_case/case_state.json
+++ b/sample_cases/demo_case/case_state.json
@@ -1,0 +1,40 @@
+{
+  "case_name": "demo_case",
+  "base_path": "sample_cases/demo_case",
+  "created_at": "2024-01-01T00:00:00",
+  "updated_at": "2024-01-01T00:00:00",
+  "factual_only": true,
+  "documents": [
+    {
+      "id": "sample-doc-1",
+      "filename": "decision.txt",
+      "doc_type": "decision",
+      "imported_at": "2024-01-01T00:00:00",
+      "original_path": "sample_cases/demo_case/imports/decision.txt",
+      "stored_path": "sample_cases/demo_case/imports/decision.txt",
+      "extracted_text_path": "sample_cases/demo_case/notes/extracted/decision_extracted.txt",
+      "notes": null,
+      "status": "text extracted"
+    }
+  ],
+  "timeline": [
+    {
+      "event_date": "2024-05-01",
+      "description": "Medical leave approved",
+      "source_document_id": "sample-doc-1"
+    },
+    {
+      "event_date": "2024-06-10",
+      "description": "Wage loss benefits recalculated",
+      "source_document_id": "sample-doc-1"
+    }
+  ],
+  "issues": [
+    {
+      "title": "Clarify wage recalculation",
+      "detail": "Request breakdown of wage loss calculation dated June 10.",
+      "related_document_id": "sample-doc-1"
+    }
+  ],
+  "drafts": []
+}

--- a/sample_cases/demo_case/imports/decision.txt
+++ b/sample_cases/demo_case/imports/decision.txt
@@ -1,0 +1,3 @@
+Decision summary:
+- Accepted medical leave from May 1 to June 15.
+- Wage loss benefits recalculated on June 10.

--- a/sample_cases/demo_case/notes/extracted/decision_extracted.txt
+++ b/sample_cases/demo_case/notes/extracted/decision_extracted.txt
@@ -1,0 +1,3 @@
+Decision summary:
+- Accepted medical leave from May 1 to June 15.
+- Wage loss benefits recalculated on June 10.

--- a/sample_cases/demo_case/policy/local_policy.txt
+++ b/sample_cases/demo_case/policy/local_policy.txt
@@ -1,0 +1,1 @@
+Sample policy text: Decisions should cite evidence, provide reasons, and explain next steps.

--- a/templates/appeal_submission.j2
+++ b/templates/appeal_submission.j2
@@ -1,0 +1,34 @@
+{{ disclaimer }}
+
+Case: {{ case_name }}
+Mode: {{ "Factual-Only" if factual_only else "Standard" }}
+
+Purpose: Appeal / Review Submission (skeleton)
+
+Summary of facts:
+{% if timeline %}
+{% for entry in timeline %}- {{ entry.event_date }} — {{ entry.description }}
+{% endfor %}
+{% else %}- Timeline not provided yet.
+{% endif %}
+
+Issues raised (neutral language):
+{% if issues %}
+{% for issue in issues %}- {{ issue.title }} — {{ issue.detail }}
+{% endfor %}
+{% else %}- Issues list not provided yet.
+{% endif %}
+
+Policy references (local only):
+{% for snippet in policy_snippets %}- {{ snippet }}
+{% endfor %}
+
+Requests:
+- Please review the facts above.
+- Please provide any clarifications needed; I will supply missing items promptly.
+- I am seeking a fair, timely review based on the information provided.
+
+Notes:
+- This helper does not give legal advice.
+- Language is intentionally neutral: "I am concerned that..." / "It appears that..."
+- No personal banking or SIN details are requested.

--- a/templates/disclosure_request.j2
+++ b/templates/disclosure_request.j2
@@ -1,0 +1,27 @@
+{{ disclaimer }}
+
+Case: {{ case_name }}
+Mode: {{ "Factual-Only" if factual_only else "Standard" }}
+
+Purpose: Disclosure Request Letter (skeleton)
+
+Facts prompting this request:
+{% if timeline %}
+{% for entry in timeline %}- {{ entry.event_date }} — {{ entry.description }}
+{% endfor %}
+{% else %}- Timeline not provided yet.
+{% endif %}
+
+Information requested:
+- Please share a copy of the full claim file, including decisions, notes, and correspondence.
+- Please include wage calculations, return-to-work planning notes, and any medical summaries on file.
+- If some items cannot be shared, please confirm what is available and the expected delivery date.
+
+Local policy references:
+{% for snippet in policy_snippets %}- {{ snippet }}
+{% endfor %}
+
+Notes:
+- This helper does not provide legal advice.
+- Language is neutral and factual.
+- No sensitive personal banking or SIN details are requested.

--- a/templates/fairness_review.j2
+++ b/templates/fairness_review.j2
@@ -1,0 +1,34 @@
+{{ disclaimer }}
+
+Case: {{ case_name }}
+Mode: {{ "Factual-Only" if factual_only else "Standard" }}
+
+Purpose: Fairness Review Letter (skeleton)
+
+Context summary:
+{% if timeline %}
+{% for entry in timeline %}- {{ entry.event_date }} — {{ entry.description }}
+{% endfor %}
+{% else %}- Timeline not provided yet.
+{% endif %}
+
+Fairness concerns:
+{% if issues %}
+{% for issue in issues %}- {{ issue.title }} — {{ issue.detail }}
+{% endfor %}
+{% else %}- Issues list not provided yet.
+{% endif %}
+
+Local policy references:
+{% for snippet in policy_snippets %}- {{ snippet }}
+{% endfor %}
+
+Requests (neutral):
+- Please review the steps taken to date and confirm that the process aligns with policy.
+- If something seems missing, I am ready to provide it promptly.
+- I appreciate a clear explanation of next steps and timelines.
+
+Notes:
+- This is not legal advice.
+- No accusations are made; statements use careful language ("It appears…", "I am concerned…").
+- No medical opinions or diagnoses are included.

--- a/wcb_app/__init__.py
+++ b/wcb_app/__init__.py
@@ -1,0 +1,5 @@
+"""WCB Super Advocate package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/wcb_app/drafts.py
+++ b/wcb_app/drafts.py
@@ -1,0 +1,109 @@
+"""Draft generation for WCB Super Advocate."""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from docx import Document as DocxDocument
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from wcb_app.models import CaseState, DraftRecord
+from wcb_app.storage import save_case_state
+from wcb_app.utils import get_resource_path
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_FILES = {
+    "appeal": "appeal_submission.j2",
+    "fairness": "fairness_review.j2",
+    "disclosure": "disclosure_request.j2",
+}
+
+
+def _load_template(template_name: str):
+    """Return a Jinja2 template from the templates directory."""
+    templates_dir = get_resource_path("templates")
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        autoescape=select_autoescape(),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return env.get_template(template_name)
+
+
+def gather_policy_snippets(policy_dir: Path) -> List[str]:
+    """Read policy text snippets from the case policy folder."""
+    if not policy_dir.exists():
+        return []
+
+    snippets: List[str] = []
+    for path in sorted(policy_dir.glob("*.txt")):
+        try:
+            snippets.append(f"{path.name}: {path.read_text(encoding='utf-8').strip()}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not read policy file %s: %s", path, exc)
+    return snippets
+
+
+def generate_draft(case_state: CaseState, draft_type: str) -> Optional[DraftRecord]:
+    """Generate both TXT and DOCX drafts."""
+    template_file = TEMPLATE_FILES.get(draft_type)
+    if not template_file:
+        logger.error("Unknown draft type: %s", draft_type)
+        return None
+
+    template = _load_template(template_file)
+    context = _build_context(case_state)
+    rendered_text = template.render(**context)
+
+    exports_dir = Path(case_state.base_path) / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+    txt_path = exports_dir / f"{draft_type}_draft_{timestamp}.txt"
+    txt_path.write_text(rendered_text, encoding="utf-8")
+
+    docx_path = exports_dir / f"{draft_type}_draft_{timestamp}.docx"
+    _write_docx(rendered_text, docx_path)
+
+    record = DraftRecord(
+        draft_type=draft_type,
+        txt_path=str(txt_path),
+        docx_path=str(docx_path),
+    )
+    case_state.drafts.append(record)
+    save_case_state(case_state)
+    logger.info("Generated %s draft at %s", draft_type, exports_dir)
+    return record
+
+
+def _build_context(case_state: CaseState) -> Dict[str, object]:
+    """Build the context dict used by Jinja templates."""
+    policy_dir = Path(case_state.base_path) / "policy"
+    policy_snippets = gather_policy_snippets(policy_dir)
+    if not policy_snippets:
+        policy_snippets = ["Policy source not provided yet."]
+
+    context = {
+        "case_name": case_state.case_name,
+        "documents": case_state.documents,
+        "timeline": case_state.timeline,
+        "issues": case_state.issues,
+        "policy_snippets": policy_snippets,
+        "factual_only": case_state.factual_only,
+        "disclaimer": (
+            "This helper does not provide legal advice. "
+            "Review all content before sending and keep language neutral."
+        ),
+    }
+    return context
+
+
+def _write_docx(text: str, output_path: Path) -> None:
+    """Write the draft text to a DOCX file."""
+    doc = DocxDocument()
+    for block in text.split("\n"):
+        doc.add_paragraph(block)
+    doc.save(output_path)

--- a/wcb_app/extraction.py
+++ b/wcb_app/extraction.py
@@ -1,0 +1,115 @@
+"""Document import and text extraction helpers."""
+
+import logging
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple
+from uuid import uuid4
+
+from docx import Document as DocxDocument
+from pypdf import PdfReader
+
+from wcb_app.models import CaseState, Document, ExtractionResult
+from wcb_app.storage import save_case_state
+from wcb_app.utils import ensure_dir
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TYPES = {".pdf", ".docx", ".txt"}
+DOCUMENT_TYPES = [
+    "decision",
+    "medical",
+    "correspondence",
+    "employer",
+    "wage",
+    "rtw",
+    "other",
+]
+
+
+def import_document(case_state: CaseState, source_path: Path, doc_type: Optional[str] = None) -> Tuple[Optional[Document], str]:
+    """Copy a document into the case and extract text."""
+    if not source_path.exists():
+        return None, "File not found. Please check the path and try again."
+
+    extension = source_path.suffix.lower()
+    if extension not in SUPPORTED_TYPES:
+        return None, "Unsupported file type. Please use PDF, DOCX, or TXT."
+
+    doc_type_value = doc_type or "other"
+    stored_name = f"{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}_{source_path.name}"
+    dest_path = Path(case_state.base_path) / "imports" / stored_name
+    ensure_dir(dest_path.parent)
+    shutil.copy2(source_path, dest_path)
+
+    document = Document(
+        filename=source_path.name,
+        doc_type=doc_type_value,
+        original_path=str(source_path),
+        stored_path=str(dest_path),
+    )
+
+    extraction_result = extract_text(document, case_state)
+    if extraction_result.success:
+        document.extracted_text_path = extraction_result.text_path
+        document.status = "text extracted"
+    else:
+        document.status = "imported"
+
+    case_state.documents.append(document)
+    save_case_state(case_state)
+    logger.info("Imported document %s", document.filename)
+
+    message = (
+        "Imported and extracted text."
+        if extraction_result.success
+        else f"Imported with warnings: {extraction_result.error_message}"
+    )
+    return document, message
+
+
+def extract_text(document: Document, case_state: CaseState) -> ExtractionResult:
+    """Extract text for a given document."""
+    stored_path = Path(document.stored_path)
+    extracted_dir = Path(case_state.base_path) / "notes" / "extracted"
+    ensure_dir(extracted_dir)
+    text_path = extracted_dir / f"{uuid4().hex}.txt"
+
+    try:
+        if stored_path.suffix.lower() == ".pdf":
+            text = _read_pdf(stored_path)
+        elif stored_path.suffix.lower() == ".docx":
+            text = _read_docx(stored_path)
+        else:
+            text = stored_path.read_text(encoding="utf-8", errors="ignore")
+        text_path.write_text(text.strip(), encoding="utf-8")
+        return ExtractionResult(doc_id=document.id, success=True, text_path=str(text_path))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to extract text from %s", stored_path)
+        return ExtractionResult(
+            doc_id=document.id,
+            success=False,
+            text_path=None,
+            error_message=f"Could not extract text: {exc}",
+        )
+
+
+def _read_pdf(path: Path) -> str:
+    """Extract text from a PDF using pypdf."""
+    reader = PdfReader(str(path))
+    texts = []
+    for page in reader.pages:
+        try:
+            texts.append(page.extract_text() or "")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Skipped a PDF page due to error: %s", exc)
+            texts.append("[Page could not be read]")
+    return "\n".join(texts)
+
+
+def _read_docx(path: Path) -> str:
+    """Extract text from a DOCX file."""
+    doc = DocxDocument(path)
+    paragraphs = [p.text for p in doc.paragraphs if p.text]
+    return "\n".join(paragraphs)

--- a/wcb_app/main.py
+++ b/wcb_app/main.py
@@ -1,0 +1,346 @@
+"""Typer CLI entrypoint for WCB Super Advocate."""
+
+import logging
+from importlib import metadata
+import platform
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from wcb_app import __version__
+from wcb_app.drafts import generate_draft
+from wcb_app.extraction import DOCUMENT_TYPES, import_document
+from wcb_app.models import CaseState, Issue, TimelineEntry
+from wcb_app.operations import build_issues, build_timeline, export_all
+from wcb_app.storage import create_case, list_cases, load_case_state, summarize_documents, summarize_issues, summarize_timeline
+from wcb_app.utils import DEFAULT_CASES_DIR, setup_logging
+
+app = typer.Typer(add_completion=False, help="WCB Super Advocate - offline-first helper")
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def run_wizard() -> None:
+    """Interactive beginner-friendly wizard."""
+    setup_logging()
+    console.print("[bold cyan]Welcome to WCB Super Advocate (offline-first)[/bold cyan]")
+    console.print("This helper keeps everything local and avoids the internet.\n")
+    case_state: Optional[CaseState] = None
+    DEFAULT_CASES_DIR.mkdir(parents=True, exist_ok=True)
+
+    while True:
+        if case_state is None:
+            choice = _choose_option(
+                "What would you like to do?",
+                [
+                    "Start new case",
+                    "Open existing case",
+                    "Diagnostics (environment info)",
+                    "Exit",
+                ],
+            )
+            if choice == 1:
+                case_state = _start_new_case()
+            elif choice == 2:
+                case_state = _open_case()
+            elif choice == 3:
+                _show_diagnostics()
+            else:
+                console.print("Goodbye. Remember to keep your files backed up locally.")
+                break
+        else:
+            console.print(f"\n[bold]Current case:[/bold] {case_state.case_name}")
+            choice = _choose_option(
+                "Select a step:",
+                [
+                    "Import documents",
+                    "Build timeline",
+                    "Build issues list",
+                    "Draft appeal/review/disclosure letter",
+                    "Export package (TXT + DOCX + JSON)",
+                    "View case summary",
+                    "Switch case",
+                    "Diagnostics",
+                    "Exit",
+                ],
+            )
+            if choice == 1:
+                _import_flow(case_state)
+            elif choice == 2:
+                _timeline_flow(case_state)
+            elif choice == 3:
+                _issues_flow(case_state)
+            elif choice == 4:
+                _draft_flow(case_state)
+            elif choice == 5:
+                _export_flow(case_state)
+            elif choice == 6:
+                _show_case_summary(case_state)
+            elif choice == 7:
+                case_state = None
+            elif choice == 8:
+                _show_diagnostics()
+            else:
+                console.print("Goodbye. You can resume by running the app again.")
+                break
+
+
+def _start_new_case() -> CaseState:
+    case_name = typer.prompt("Enter a case name").strip()
+    safe_name = case_name.replace("\\", "_").replace("/", "_").replace(" ", "_")
+    factual_only = typer.confirm("Enable Factual-Only Mode? (recommended)", default=True)
+    case_state = create_case(safe_name, factual_only=factual_only)
+    console.print(f"Created case at {case_state.base_path}")
+    console.print("Next step: import documents.")
+    typer.prompt("Press Enter to continue")
+    return case_state
+
+
+def _open_case() -> Optional[CaseState]:
+    available = list_cases()
+    if not available:
+        console.print("No cases found yet. Start a new case first.")
+        typer.prompt("Press Enter to continue")
+        return None
+
+    console.print("\nAvailable cases:")
+    for idx, name in enumerate(available, start=1):
+        console.print(f"{idx}. {name}")
+
+    selection = typer.prompt("Enter the number of the case to open")
+    try:
+        index = int(selection) - 1
+        if index < 0 or index >= len(available):
+            raise ValueError
+    except ValueError:
+        console.print("Invalid choice. Returning to menu.")
+        return None
+
+    base_path = DEFAULT_CASES_DIR / available[index]
+    case_state = load_case_state(base_path)
+    console.print(f"Opened case '{case_state.case_name}'.")
+    typer.prompt("Press Enter to continue")
+    return case_state
+
+
+def _import_flow(case_state: CaseState) -> None:
+    console.print("\nImport a document (PDF/DOCX/TXT). Files will be copied into the case folder.")
+    path_input = typer.prompt("Enter the full path to the document")
+    doc_type = _choose_doc_type()
+    document, message = import_document(case_state, Path(path_input), doc_type)
+    console.print(message)
+    if document:
+        console.print(f"Stored as: {document.stored_path}")
+    console.print("Next step: build the timeline or add issues.")
+    typer.prompt("Press Enter to continue")
+
+
+def _timeline_flow(case_state: CaseState) -> None:
+    console.print("\nBuild the case timeline. Keep entries short and factual.")
+    _show_existing_timeline(case_state)
+    new_entries: List[TimelineEntry] = []
+    while True:
+        date_value = typer.prompt("Event date (YYYY-MM-DD, leave blank to finish)", default="")
+        if not date_value.strip():
+            break
+        description = typer.prompt("Brief description of the event")
+        doc_id = _choose_document(case_state, allow_skip=True)
+        new_entries.append(
+            TimelineEntry(
+                event_date=date_value.strip(),
+                description=description.strip(),
+                source_document_id=doc_id,
+            )
+        )
+    if new_entries:
+        build_timeline(case_state, new_entries)
+        console.print(f"Added {len(new_entries)} timeline entries.")
+    else:
+        console.print("No new entries added.")
+    console.print("Next step: add issues or generate a draft.")
+    typer.prompt("Press Enter to continue")
+
+
+def _issues_flow(case_state: CaseState) -> None:
+    console.print("\nList the issues you want to flag (neutral language).")
+    _show_existing_issues(case_state)
+    new_issues: List[Issue] = []
+    while True:
+        title = typer.prompt("Issue title (leave blank to finish)", default="")
+        if not title.strip():
+            break
+        detail = typer.prompt("What is the concern? Use neutral language.")
+        doc_id = _choose_document(case_state, allow_skip=True)
+        new_issues.append(
+            Issue(title=title.strip(), detail=detail.strip(), related_document_id=doc_id)
+        )
+    if new_issues:
+        build_issues(case_state, new_issues)
+        console.print(f"Added {len(new_issues)} issues.")
+    else:
+        console.print("No new issues added.")
+    console.print("Next step: generate a draft or export package.")
+    typer.prompt("Press Enter to continue")
+
+
+def _draft_flow(case_state: CaseState) -> None:
+    console.print("\nDraft options use local templates and stay factual.")
+    choice = _choose_option(
+        "Choose a draft to generate",
+        [
+            "Appeal/Review submission skeleton",
+            "Fairness Review letter skeleton",
+            "Disclosure request letter skeleton",
+            "Cancel",
+        ],
+    )
+    mapping = {1: "appeal", 2: "fairness", 3: "disclosure"}
+    draft_type = mapping.get(choice)
+    if not draft_type:
+        console.print("Cancelled. No draft created.")
+        return
+    record = generate_draft(case_state, draft_type)
+    if record:
+        console.print(f"Draft saved to:\n- {record.txt_path}\n- {record.docx_path}")
+    else:
+        console.print("Could not generate the draft.")
+    console.print("Next step: review the draft and export the package.")
+    typer.prompt("Press Enter to continue")
+
+
+def _export_flow(case_state: CaseState) -> None:
+    path = export_all(case_state)
+    console.print(f"Exported timeline, issues, and checklist to {path}")
+    console.print("Next step: review files in the exports folder.")
+    typer.prompt("Press Enter to continue")
+
+
+def _show_case_summary(case_state: CaseState) -> None:
+    console.print("\n[bold]Case summary[/bold]")
+    console.print(f"Case name: {case_state.case_name}")
+    console.print(f"Location: {case_state.base_path}")
+    console.print(f"Factual-Only Mode: {'ON' if case_state.factual_only else 'OFF'}")
+    console.print("\nDocuments:")
+    console.print(summarize_documents(case_state.documents))
+    console.print("\nTimeline:")
+    console.print(summarize_timeline(case_state.timeline))
+    console.print("\nIssues:")
+    console.print(summarize_issues(case_state.issues))
+    console.print("\nNext step: import documents or draft a letter.")
+    typer.prompt("Press Enter to continue")
+
+
+def _show_existing_timeline(case_state: CaseState) -> None:
+    if not case_state.timeline:
+        console.print("No timeline entries yet.")
+        return
+    table = Table(title="Existing timeline")
+    table.add_column("Date")
+    table.add_column("Description")
+    for entry in case_state.timeline:
+        table.add_row(entry.event_date, entry.description)
+    console.print(table)
+
+
+def _show_existing_issues(case_state: CaseState) -> None:
+    if not case_state.issues:
+        console.print("No issues recorded yet.")
+        return
+    table = Table(title="Existing issues")
+    table.add_column("Title")
+    table.add_column("Detail")
+    for issue in case_state.issues:
+        table.add_row(issue.title, issue.detail)
+    console.print(table)
+
+
+def _choose_option(prompt_text: str, options: List[str]) -> int:
+    console.print(f"\n{prompt_text}")
+    for idx, opt in enumerate(options, start=1):
+        console.print(f"{idx}. {opt}")
+    while True:
+        selection = typer.prompt("Enter a number")
+        try:
+            value = int(selection)
+            if 1 <= value <= len(options):
+                return value
+        except ValueError:
+            pass
+        console.print("Please choose a listed number.")
+
+
+def _choose_doc_type() -> str:
+    console.print("Select a tag for this document (or press Enter for 'other').")
+    for idx, doc_type in enumerate(DOCUMENT_TYPES, start=1):
+        console.print(f"{idx}. {doc_type}")
+    selection = typer.prompt("Enter a number", default="")
+    try:
+        index = int(selection) - 1
+        if 0 <= index < len(DOCUMENT_TYPES):
+            return DOCUMENT_TYPES[index]
+    except ValueError:
+        pass
+    return "other"
+
+
+def _choose_document(case_state: CaseState, allow_skip: bool = False) -> Optional[str]:
+    """Return a document ID or None."""
+    if not case_state.documents:
+        return None
+    console.print("Link to a document? Choose a number or press Enter to skip.")
+    for idx, doc in enumerate(case_state.documents, start=1):
+        console.print(f"{idx}. {doc.filename} ({doc.doc_type})")
+    if allow_skip:
+        console.print("0. Skip linking")
+    selection = typer.prompt("Enter choice", default="")
+    if selection.strip() == "" or selection == "0":
+        return None
+    try:
+        index = int(selection) - 1
+        if 0 <= index < len(case_state.documents):
+            return case_state.documents[index].id
+    except ValueError:
+        pass
+    console.print("No document linked.")
+    return None
+
+
+def _show_diagnostics() -> None:
+    console.print("\n[bold]Diagnostics[/bold]")
+    console.print(f"Python: {platform.python_version()}")
+    console.print(f"Platform: {platform.platform()}")
+    console.print(f"App version: {__version__}")
+    console.print(f"Cases directory: {DEFAULT_CASES_DIR}")
+    deps = ["typer", "rich", "pydantic", "python-docx", "pypdf", "jinja2", "PyInstaller"]
+    for dep in deps:
+        version = _get_dep_version(dep)
+        console.print(f"- {dep}: {version}")
+    typer.prompt("Press Enter to continue")
+
+
+def _get_dep_version(package_name: str) -> str:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        return "not installed"
+
+
+@app.command()
+def wizard() -> None:
+    """Launch the guided wizard."""
+    run_wizard()
+
+
+@app.command()
+def diagnostics() -> None:
+    """Show environment diagnostics."""
+    setup_logging()
+    _show_diagnostics()
+
+
+if __name__ == "__main__":
+    app()

--- a/wcb_app/models.py
+++ b/wcb_app/models.py
@@ -1,0 +1,75 @@
+"""Pydantic models for WCB Super Advocate."""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+def new_id() -> str:
+    """Return a new identifier string."""
+    return uuid4().hex
+
+
+class Document(BaseModel):
+    """Represents an imported document."""
+
+    id: str = Field(default_factory=new_id)
+    filename: str
+    doc_type: str = "other"
+    imported_at: datetime = Field(default_factory=datetime.utcnow)
+    original_path: str
+    stored_path: str
+    extracted_text_path: Optional[str] = None
+    notes: Optional[str] = None
+    status: str = "imported"
+
+
+class ExtractionResult(BaseModel):
+    """Captures extraction status for a document."""
+
+    doc_id: str
+    success: bool
+    text_path: Optional[str] = None
+    error_message: Optional[str] = None
+
+
+class TimelineEntry(BaseModel):
+    """Chronological entry for the case timeline."""
+
+    event_date: str
+    description: str
+    source_document_id: Optional[str] = None
+
+
+class Issue(BaseModel):
+    """Represents an issue or concern for the case."""
+
+    title: str
+    detail: str
+    related_document_id: Optional[str] = None
+
+
+class DraftRecord(BaseModel):
+    """Tracks generated draft artifacts."""
+
+    draft_type: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    txt_path: str
+    docx_path: str
+
+
+class CaseState(BaseModel):
+    """Overall state for a WCB case."""
+
+    case_name: str
+    base_path: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    factual_only: bool = True
+    documents: List[Document] = Field(default_factory=list)
+    timeline: List[TimelineEntry] = Field(default_factory=list)
+    issues: List[Issue] = Field(default_factory=list)
+    drafts: List[DraftRecord] = Field(default_factory=list)
+

--- a/wcb_app/operations.py
+++ b/wcb_app/operations.py
@@ -1,0 +1,91 @@
+"""High-level case operations for WCB Super Advocate."""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+from wcb_app.models import CaseState, Issue, TimelineEntry
+from wcb_app.storage import save_case_state
+
+logger = logging.getLogger(__name__)
+
+
+def build_timeline(case_state: CaseState, entries: Iterable[TimelineEntry]) -> None:
+    """Append timeline entries and persist."""
+    new_entries = list(entries)
+    case_state.timeline.extend(new_entries)
+    save_case_state(case_state)
+    logger.info("Added %s timeline entries", len(new_entries))
+
+
+def build_issues(case_state: CaseState, issues: Iterable[Issue]) -> None:
+    """Append issues and persist."""
+    new_issues = list(issues)
+    case_state.issues.extend(new_issues)
+    save_case_state(case_state)
+    logger.info("Added %s issues", len(new_issues))
+
+
+def export_all(case_state: CaseState) -> Path:
+    """Export timeline, issues, and a contradictions checklist."""
+    exports_dir = Path(case_state.base_path) / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+
+    timeline_txt = exports_dir / f"timeline_{timestamp}.txt"
+    timeline_json = exports_dir / f"timeline_{timestamp}.json"
+    issues_txt = exports_dir / f"issues_{timestamp}.txt"
+    issues_json = exports_dir / f"issues_{timestamp}.json"
+    checklist_txt = exports_dir / f"contradictions_checklist_{timestamp}.txt"
+
+    timeline_txt.write_text(_format_timeline_text(case_state.timeline), encoding="utf-8")
+    timeline_json.write_text(json.dumps([entry.model_dump() for entry in case_state.timeline], indent=2), encoding="utf-8")
+
+    issues_txt.write_text(_format_issues_text(case_state.issues), encoding="utf-8")
+    issues_json.write_text(json.dumps([issue.model_dump() for issue in case_state.issues], indent=2), encoding="utf-8")
+
+    checklist_txt.write_text(_build_checklist(case_state), encoding="utf-8")
+
+    save_case_state(case_state)
+    logger.info("Exported case package to %s", exports_dir)
+    return exports_dir
+
+
+def _format_timeline_text(timeline: List[TimelineEntry]) -> str:
+    if not timeline:
+        return "No timeline entries recorded yet."
+    lines = ["Case Timeline:"]
+    for entry in timeline:
+        lines.append(f"- {entry.event_date}: {entry.description}")
+    return "\n".join(lines)
+
+
+def _format_issues_text(issues: List[Issue]) -> str:
+    if not issues:
+        return "No issues recorded yet."
+    lines = ["Case Issues:"]
+    for issue in issues:
+        lines.append(f"- {issue.title}: {issue.detail}")
+    return "\n".join(lines)
+
+
+def _build_checklist(case_state: CaseState) -> str:
+    """Build a gentle contradictions checklist."""
+    lines = [
+        "Contradictions Checklist (neutral language):",
+        "- Compare decision dates against documented medical visits.",
+        "- Confirm wage information matches employer records.",
+        "- Verify return-to-work discussions align with correspondence.",
+        "- Note any unclear statements to ask about (avoid accusations).",
+        "",
+        "Observed timeline entries:",
+    ]
+    lines.extend([f"* {entry.event_date}: {entry.description}" for entry in case_state.timeline])
+    lines.append("")
+    lines.append("Observed issues:")
+    lines.extend([f"* {issue.title}: {issue.detail}" for issue in case_state.issues])
+    lines.append("")
+    lines.append("Reminder: This is not legal advice. Keep requests neutral and fact-based.")
+    return "\n".join(lines)

--- a/wcb_app/storage.py
+++ b/wcb_app/storage.py
@@ -1,0 +1,101 @@
+"""Case storage and state helpers."""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from wcb_app.models import CaseState, Document, Issue, TimelineEntry
+from wcb_app.utils import DEFAULT_CASES_DIR, ensure_dir
+
+logger = logging.getLogger(__name__)
+
+
+def case_path(case_name: str, cases_dir: Path = DEFAULT_CASES_DIR) -> Path:
+    """Return the path for a named case."""
+    return cases_dir / case_name
+
+
+def create_case(case_name: str, factual_only: bool = True) -> CaseState:
+    """Initialize a new case folder and state."""
+    base_path = case_path(case_name)
+    imports_dir = base_path / "imports"
+    exports_dir = base_path / "exports"
+    policy_dir = base_path / "policy"
+    notes_dir = base_path / "notes"
+
+    for folder in [imports_dir, exports_dir, policy_dir, notes_dir]:
+        ensure_dir(folder)
+
+    state = CaseState(
+        case_name=case_name,
+        base_path=str(base_path),
+        factual_only=factual_only,
+    )
+    save_case_state(state)
+    logger.info("Created case '%s' at %s", case_name, base_path)
+    return state
+
+
+def save_case_state(case_state: CaseState) -> None:
+    """Persist the case state to disk."""
+    base_path = Path(case_state.base_path)
+    ensure_dir(base_path)
+    case_state.updated_at = datetime.utcnow()
+    state_path = base_path / "case_state.json"
+    state_path.write_text(
+        json.dumps(case_state.model_dump(), indent=2, default=str),
+        encoding="utf-8",
+    )
+    logger.info("Saved case state to %s", state_path)
+
+
+def load_case_state(base_path: Path) -> CaseState:
+    """Load a case state from disk."""
+    state_path = base_path / "case_state.json"
+    data = json.loads(state_path.read_text(encoding="utf-8"))
+    state = CaseState.model_validate(data)
+    logger.info("Loaded case state from %s", state_path)
+    return state
+
+
+def load_case(base_path: Path) -> CaseState:
+    """Alias for loading a case to align with the public API."""
+    return load_case_state(base_path)
+
+
+def list_cases(cases_dir: Path = DEFAULT_CASES_DIR) -> List[str]:
+    """List available case folders."""
+    ensure_dir(cases_dir)
+    return sorted(
+        [p.name for p in cases_dir.iterdir() if p.is_dir() and (p / "case_state.json").exists()]
+    )
+
+
+def summarize_documents(documents: List[Document]) -> str:
+    """Return a human-readable summary of documents."""
+    if not documents:
+        return "No documents imported yet."
+    lines = []
+    for doc in documents:
+        label = f"{doc.filename} ({doc.doc_type})"
+        status = "with extracted text" if doc.extracted_text_path else "imported"
+        lines.append(f"- {label} [{status}]")
+    return "\n".join(lines)
+
+
+def summarize_timeline(timeline: List[TimelineEntry]) -> str:
+    """Return a human-readable summary of the timeline."""
+    if not timeline:
+        return "No timeline entries yet."
+    lines = [f"- {entry.event_date}: {entry.description}" for entry in timeline]
+    return "\n".join(lines)
+
+
+def summarize_issues(issues: List[Issue]) -> str:
+    """Return a human-readable summary of issues."""
+    if not issues:
+        return "No issues recorded yet."
+    lines = [f"- {issue.title}: {issue.detail}" for issue in issues]
+    return "\n".join(lines)

--- a/wcb_app/utils.py
+++ b/wcb_app/utils.py
@@ -1,0 +1,57 @@
+"""Shared utilities for WCB Super Advocate."""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+LOG_PATH = Path.cwd() / "logs" / "app.log"
+DEFAULT_CASES_DIR = Path.cwd() / "cases"
+
+
+def setup_logging() -> None:
+    """Configure application logging."""
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    handlers = [
+        logging.FileHandler(LOG_PATH, encoding="utf-8"),
+        logging.StreamHandler(),
+    ]
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
+
+
+def get_resource_path(relative_path: str) -> Path:
+    """Resolve resource paths for PyInstaller or source runs."""
+    base_path: Path
+    if getattr(sys, "frozen", False):
+        base_path = Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    else:
+        base_path = Path(__file__).resolve().parents[1]
+    return base_path / relative_path
+
+
+def ensure_dir(path: Path) -> Path:
+    """Create a directory if missing."""
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def safe_copy(src: Path, dest: Path) -> Path:
+    """Copy a file while ensuring the destination directory exists."""
+    ensure_dir(dest.parent)
+    data = src.read_bytes()
+    dest.write_bytes(data)
+    return dest
+
+
+def read_text_file(path: Path, fallback_message: Optional[str] = None) -> str:
+    """Read a UTF-8 text file with a friendly fallback."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception:
+        if fallback_message:
+            return fallback_message
+        raise


### PR DESCRIPTION
## Summary
- add an offline-first Typer wizard for creating/loading cases, importing documents, building timelines/issues, and exporting drafts
- generate local-only Jinja2-based letter templates plus a demo case to guide new users
- provide Windows build/run scripts, requirements file, and updated README instructions for one-click execution

## Testing
- python -m pip install -r requirements.txt *(fails: proxy blocked download for python-docx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69551f5449c48329b6030d3dec318422)