### PR TITLE
Add configurable Drive folder IDs and base prompt guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REFRESH_TOKEN=
 CASE_VAULT_PATH=./case-vault
+# Comma-separated Drive folder IDs to scan (defaults to root if omitted)
+GOOGLE_DRIVE_FOLDER_IDS=root

--- a/wcb-agent/README.md
+++ b/wcb-agent/README.md
@@ -33,6 +33,7 @@ All configuration lives in `.env`. At minimum, provide:
 - `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (OAuth client credentials)
 - `GOOGLE_REFRESH_TOKEN` (authorized for Gmail and Drive scopes)
 - `CASE_VAULT_PATH` (local folder containing PDFs/scans)
+- `GOOGLE_DRIVE_FOLDER_IDS` (optional, comma-separated list of Drive folder IDs to scan; defaults to `root`)
 
 ## Project layout
 - `app/main.py` – FastAPI entrypoint exposing health and data refresh endpoints.

--- a/wcb-agent/app/agents/analysis.py
+++ b/wcb-agent/app/agents/analysis.py
@@ -8,6 +8,31 @@ from langchain.chat_models import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema import Document
 
+PRIMARY_SYSTEM_PROMPT = """\
+## PRIMARY SYSTEM PROMPT
+You are "WCB Super Advocate," an autonomous legal strategy assistant specializing exclusively in Alberta Workers’ Compensation Board (WCB) cases.
+Operate in factual-only mode using official WCB Alberta policies, directives, manuals, and publicly available decisions.
+Never speculate or invent policy.
+
+## CAPABILITIES / STRENGTHS (NON-USER-EDITABLE)
+- Organize WCB documents and correspondence.
+- Identify procedural errors, policy application issues, and fairness concerns.
+- Draft submission-ready correspondence for Fairness Review, Appeals Commission, and caseworkers.
+- Build concise timelines and issue summaries.
+- Explain WCB processes in plain language for beginners.
+
+## BEHAVIOR RULES (NON-USER-EDITABLE)
+- Beginner-first explanations.
+- Voice-compatible, short sentences.
+- Step-by-step guidance only.
+- Calm, compassionate tone.
+
+## CONSTRAINTS / ERROR-HANDLING (NON-USER-EDITABLE)
+- Do not guess or hallucinate policy.
+- If information is unavailable, say so explicitly.
+- Scope is limited to Alberta WCB only.
+"""
+
 
 @dataclass
 class AgentResult:
@@ -23,6 +48,7 @@ class BaseCaseAgent:
 
     def __init__(self, *, model_name: str = "gpt-4o-mini") -> None:
         self.llm = ChatOpenAI(model_name=model_name)
+        self.base_system_prompt = PRIMARY_SYSTEM_PROMPT
 
     def run(self, context: List[Document]) -> AgentResult:  # pragma: no cover - orchestrated externally
         raise NotImplementedError
@@ -32,7 +58,7 @@ class BaseCaseAgent:
             [
                 (
                     "system",
-                    instructions,
+                    f"{self.base_system_prompt}\n\n## ROLE-SPECIFIC INSTRUCTIONS\n{instructions}",
                 ),
                 (
                     "human",

--- a/wcb-agent/app/config.py
+++ b/wcb-agent/app/config.py
@@ -1,8 +1,8 @@
 """Configuration management for the WCB agent."""
 from functools import lru_cache
-from typing import Optional
+from typing import List, Optional
 
-from pydantic import BaseSettings, Field, HttpUrl
+from pydantic import BaseSettings, Field, HttpUrl, field_validator
 
 
 class Settings(BaseSettings):
@@ -13,6 +13,11 @@ class Settings(BaseSettings):
     google_client_secret: str = Field(..., env="GOOGLE_CLIENT_SECRET")
     google_refresh_token: str = Field(..., env="GOOGLE_REFRESH_TOKEN")
     case_vault_path: str = Field(..., env="CASE_VAULT_PATH")
+    drive_folder_ids: List[str] = Field(
+        default_factory=lambda: ["root"],
+        env="GOOGLE_DRIVE_FOLDER_IDS",
+        description="Comma-separated list of Drive folder IDs to scan for WCB documents.",
+    )
 
     webhook_base_url: Optional[HttpUrl] = Field(
         None,
@@ -22,6 +27,15 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = True
+
+    @field_validator("drive_folder_ids", mode="before")
+    @classmethod
+    def _split_drive_ids(cls, value: str | List[str] | None) -> List[str]:
+        if value is None:
+            return ["root"]
+        if isinstance(value, list):
+            return value
+        return [item.strip() for item in value.split(",") if item.strip()]
 
 
 @lru_cache()

--- a/wcb-agent/app/routers/cases.py
+++ b/wcb-agent/app/routers/cases.py
@@ -99,7 +99,9 @@ def refresh_case(  # pragma: no cover - integration focused
     vault_loader = VaultLoader(settings.case_vault_path)
 
     gmail_messages = gmail_client.fetch_recent_messages(query="subject:WCB OR WCB", max_results=50)
-    drive_files = drive_client.list_case_files(folder_id="root")
+    drive_files = []
+    for folder_id in settings.drive_folder_ids:
+        drive_files.extend(drive_client.list_case_files(folder_id=folder_id))
     vault_paths = [str(path) for path in vault_loader.discover_files()]
 
     documents = [


### PR DESCRIPTION
## Summary
- add configurable Drive folder IDs to settings to support multiple case folders
- update case refresh to iterate over configured Drive folders
- document the new environment variable in README and .env.example
- add immutable, sectioned system prompt enforced at agent initialization for all specialized modules

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69552337415483299eeda7ae14160d8d)